### PR TITLE
Customize HTTP header in response (and allow not to include the header at all)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,7 @@ language: python
 python:
   - "2.7"
 
-cache:
-  directories:
-    - $HOME/.pip-cache
-
 env:
-  global:
-    - PIP_OPTS="--download-cache $HOME/.pip-cache"
-
   matrix:
     - TOX_ENV=py27-1.8
     - TOX_ENV=py27-1.7
@@ -22,10 +15,10 @@ env:
     - TOX_ENV=py34-1.6
 
 install:
-  - pip install $PIP_OPTS -U setuptools wheel
+  - pip install -U setuptools wheel
   - python setup.py develop
-  - pip install $PIP_OPTS --use-wheel -U -r requirements/ci.txt
-  - pip install $PIP_OPTS tox
+  - pip install --use-wheel -U -r requirements/ci.txt
+  - pip install tox
 
 script:
   - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,19 @@ python:
 
 env:
   matrix:
+    - TOX_ENV=py27-1.10
+    - TOX_ENV=py34-1.10
+    - TOX_ENV=py35-1.10
+    - TOX_ENV=py27-1.9
+    - TOX_ENV=py34-1.9
+    - TOX_ENV=py35-1.9
     - TOX_ENV=py27-1.8
-    - TOX_ENV=py27-1.7
-    - TOX_ENV=py27-1.6
     - TOX_ENV=py33-1.8
-    - TOX_ENV=py33-1.7
-    - TOX_ENV=py33-1.6
     - TOX_ENV=py34-1.8
+    - TOX_ENV=py35-1.8
+    - TOX_ENV=py27-1.7
+    - TOX_ENV=py33-1.7
     - TOX_ENV=py34-1.7
-    - TOX_ENV=py34-1.6
 
 install:
   - pip install -U setuptools wheel

--- a/cid/middleware.py
+++ b/cid/middleware.py
@@ -7,15 +7,20 @@ from .locals import set_cid, get_cid
 class CidMiddleware(object):
     """
     Middleware class to extract the correlation id from incoming headers
-    and add them to out going headers
+    and add them to outgoing headers
     """
 
     def __init__(self):
-        self.cid_header = getattr(settings, 'CID_HEADER', 'X_CORRELATION_ID')
+        self.cid_request_header = getattr(
+            settings, 'CID_HEADER', 'X_CORRELATION_ID'
+        )
+        self.cid_response_header = getattr(
+            settings, 'CID_RESPONSE_HEADER', self.cid_request_header
+        )
         self.generate_cid = getattr(settings, 'CID_GENERATE', False)
 
     def process_request(self, request):
-        cid = request.META.get(self.cid_header, None)
+        cid = request.META.get(self.cid_request_header, None)
         if cid is None and self.generate_cid:
             cid = str(uuid4())
         request.correlation_id = cid
@@ -23,6 +28,6 @@ class CidMiddleware(object):
 
     def process_response(self, request, response):
         cid = get_cid()
-        if cid:
-            response[self.cid_header] = cid
+        if cid and self.cid_response_header:
+            response[self.cid_response_header] = cid
         return response

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -43,6 +43,36 @@ your settings file:
 
     CID_GENERATE = True
 
+By default, Django Correlation Id sets an HTTP header in the HTTP
+response with the same name as configured in ``CID_HEADER``. You may
+customize it with ``CID_RESPONSE_HEADER`` in the settings:
+
+.. code-block:: python
+
+    CID_RESPONSE_HEADER = 'X-Something-Completely-Different'
+
+.. note::
+
+    As indicated in the note above, if Django is behind a WSGI server
+    that sanitizes HTTP headers, you need to customize
+    ``CID_RESPONSE_HEADER`` to have the same header name in the
+    response as in the request.
+
+    .. code-block:: python
+
+        # The header is ``X-Correlation-Id`` but is sanitized by the WSGI server.
+        CID_HEADER = 'HTTP_X_CORRELATION_ID'
+        # Don't use the default value (equal to CID_HEADER) for the response header.
+        CID_RESPONSE_HEADER = 'X-Correlation-Id'
+
+If you don't want the header to appear in the HTTP response, you must
+explicitly set ``CID_REQUEST_HEADER`` to ``None``.
+
+    .. code-block:: python
+
+        # Don't include the header in the HTTP response.
+        CID_RESPONSE_HEADER = None
+
 
 SQL Comments
 ------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -26,6 +26,15 @@ used by putting a value into settings for the ``CID_HEADER``. e.g.:
 
     CID_HEADER = 'X_MY_CID_HEADER'
 
+.. note::
+
+    Most WSGI implementations sanitize HTTP headers by appending an
+    ``HTTP_`` prefix and replacing ``-`` by ``_``. For example, an
+    incoming ``X-Correlation-Id`` header would be available as
+    ``HTTP_X_CORRELATION_ID`` in Django. When using such a WSGI server
+    in front of Django, the latter, sanitized value should be used in
+    the settings.
+
 You can also configure Django Correlation Id to generate it's own correlation
 id if one if not found in the header. For this set ``CID_GENERATE`` to true in
 you settings file:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -35,9 +35,9 @@ used by putting a value into settings for the ``CID_HEADER``. e.g.:
     in front of Django, the latter, sanitized value should be used in
     the settings.
 
-You can also configure Django Correlation Id to generate it's own correlation
-id if one if not found in the header. For this set ``CID_GENERATE`` to true in
-you settings file:
+You can also configure Django Correlation Id to generate its own correlation
+id if one is not found in the header. For this set ``CID_GENERATE`` to true in
+your settings file:
 
 .. code-block:: python
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -60,6 +60,26 @@ class TestCidMiddleware(TestCase):
         self.assertEqual(response['X_CORRELATION_ID'], self.cid)
 
     @patch('cid.middleware.get_cid')
+    @override_settings(CID_RESPONSE_HEADER="X-Custom-Name")
+    def test_process_response_custom_header_name(self, get_cid):
+        get_cid.return_value = self.cid
+        request = Mock()
+        response = {}
+        middleware = CidMiddleware()
+        response = middleware.process_response(request, response)
+        self.assertEqual(response['X-Custom-Name'], self.cid)
+
+    @patch('cid.middleware.get_cid')
+    @override_settings(CID_RESPONSE_HEADER=None)
+    def test_process_response_no_header(self, get_cid):
+        get_cid.return_value = self.cid
+        request = Mock()
+        response = {}
+        middleware = CidMiddleware()
+        response = middleware.process_response(request, response)
+        self.assertNotIn('X_CORRELATION_ID', response.keys())
+
+    @patch('cid.middleware.get_cid')
     def test_process_response_with_no_cid(self, get_cid):
         get_cid.return_value = None
         request = Mock()

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,46 @@
 [tox]
-envlist = py27-1.8, py33-1.8, py34-1.8, py27-1.7, py33-1.7, py34-1.7, py27-1.6, py33-1.6, py34-1.6, docs
+envlist = py27-1.10, py34-1.10, py35-1.10, py27-1.9, py34-1.9, py35-1.9, py27-1.8, py33-1.8, py34-1.8, py35-1.8, py27-1.7, py33-1.7, py34-1.7, docs
 
 [testenv]
 commands = python runtests.py
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/cid
+
+[testenv:py27-1.10]
+basepython = python2.7
+deps =
+    -r{toxinidir}/requirements/ci.txt
+    django>=1.10,<1.11
+
+[testenv:py34-1.10]
+basepython = python3.4
+deps =
+    -r{toxinidir}/requirements/ci.txt
+    django>=1.10,<1.11
+
+[testenv:py35-1.10]
+basepython = python3.5
+deps =
+    -r{toxinidir}/requirements/ci.txt
+    django>=1.10,<1.11
+
+[testenv:py27-1.9]
+basepython = python2.7
+deps =
+    -r{toxinidir}/requirements/ci.txt
+    django>=1.9,<1.10
+
+[testenv:py34-1.9]
+basepython = python3.4
+deps =
+    -r{toxinidir}/requirements/ci.txt
+    django>=1.9,<1.10
+
+[testenv:py35-1.9]
+basepython = python3.5
+deps =
+    -r{toxinidir}/requirements/ci.txt
+    django>=1.9,<1.10
 
 [testenv:py27-1.8]
 basepython = python2.7
@@ -20,6 +56,12 @@ deps =
 
 [testenv:py34-1.8]
 basepython = python3.4
+deps =
+    -r{toxinidir}/requirements/ci.txt
+    django>=1.8,<1.9
+
+[testenv:py35-1.8]
+basepython = python3.5
 deps =
     -r{toxinidir}/requirements/ci.txt
     django>=1.8,<1.9
@@ -41,24 +83,6 @@ basepython = python3.4
 deps =
     -r{toxinidir}/requirements/ci.txt
     django>=1.7,<1.8
-
-[testenv:py27-1.6]
-basepython = python2.7
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.6,<1.7
-
-[testenv:py33-1.6]
-basepython = python3.3
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.6,<1.7
-
-[testenv:py34-1.6]
-basepython = python3.4
-deps =
-    -r{toxinidir}/requirements/ci.txt
-    django>=1.6,<1.7
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
Hi,

We're using this package on several projects (only for the logging features, not the SQL comments yet) and it's very useful. Thanks for making it open source!

We have found that having the header included in the HTTP response was not useful to us (at least yet) and even though leaking it should not be an issue, we'd prefer not to have the header in the HTTP response at all. The proposed change allows that.

Also, the proposed change allows to customize the name of the header in the HTTP response. This is especially useful if Django is behind a WSGI server that sanitizes the HTTP header name (and I believe most WSGI servers do):

    # The header is `X-Correlation-Id` but is sanitized by the WSGI server.
    # Here we must provide the sanitized name.
    CID_HEADER = 'HTTP_X_CORRELATION_ID'
    # Do not use the default value (equal to CID_HEADER) for the
    # response header: we want to have the same header name
    # on ingress and egress.
    CID_RESPONSE_HEADER = 'X-Correlation-Id'

Hopefully the change is simple enough and backward compatible. Is it something that you think you could merge?