### PR TITLE
middleware: add Django 1.10 compatibility

### DIFF
--- a/cid/middleware.py
+++ b/cid/middleware.py
@@ -1,16 +1,22 @@
 from uuid import uuid4
 from django.conf import settings
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:  # Django < 1.10
+    MiddlewareMixin = object
+
 from .locals import set_cid, get_cid
 
 
-class CidMiddleware(object):
+class CidMiddleware(MiddlewareMixin):
     """
     Middleware class to extract the correlation id from incoming headers
     and add them to outgoing headers
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        super(CidMiddleware, self).__init__(*args, **kwargs)
         self.cid_request_header = getattr(
             settings, 'CID_HEADER', 'X_CORRELATION_ID'
         )

--- a/sandbox/urls.py
+++ b/sandbox/urls.py
@@ -1,11 +1,14 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 
-urlpatterns = patterns(
-    '',
+from .views import ping_view
+
+
+urlpatterns = (
     # Examples:
     # url(r'^$', 'sandbox.views.home', name='home'),
     # url(r'^blog/', include('blog.urls')),
 
+    url(r'^ping/$', ping_view, name='ping'),
     url(r'^admin/', include(admin.site.urls)),
 )

--- a/sandbox/views.py
+++ b/sandbox/views.py
@@ -1,0 +1,5 @@
+from django.http import HttpResponse
+
+
+def ping_view(request, *args, **kwargs):
+    return HttpResponse('OK')


### PR DESCRIPTION
This fixes an error with Django 1.10 middleware initialization
that requires one more argument.
(see https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware)

This works with Django 1.7 to 1.10.